### PR TITLE
Fix 4.1.0 integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,12 +23,7 @@ subprojects {
   dependencies {
     provided(fileTree(dir: "${fusionHome}/apps/connectors/connectors-rpc/libs", include: '*.jar'))
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    compile(group: 'org.apache.chemistry.opencmis', name: 'chemistry-opencmis-client-impl', version: '1.1.0'){
-      exclude group: 'org.slf4j'
-    }
     // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
-    compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.0'
-
   }
 
   jar {

--- a/random-connector/build.gradle
+++ b/random-connector/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+  compile(group: 'org.apache.chemistry.opencmis', name: 'chemistry-opencmis-client-impl', version: '1.1.0') {
+    exclude group: 'org.slf4j'
+    exclude group: 'javax.xml.stream', module: 'stax-api'
+  }
+  compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.0'
+}

--- a/random-connector/src/main/java/com/lucidworks/fusion/connector/plugin/PnTConnectorClient.java
+++ b/random-connector/src/main/java/com/lucidworks/fusion/connector/plugin/PnTConnectorClient.java
@@ -8,73 +8,80 @@ import org.apache.chemistry.opencmis.commons.SessionParameter;
 import org.apache.chemistry.opencmis.commons.enums.BindingType;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class PnTConnectorClient {
 
-    private SessionFactory sessionFactory = SessionFactoryImpl.newInstance();
-    private Session session;
-    private String CMIS_BROWSER_BINDING_URL = "https://alfpnt.intranet.dev.int.devlab.redhat.com/alfresco/api/-default-/public/cmis/versions/1.1/browser";
-    File keyStore;
+  private static final Logger logger = LogManager.getLogger(PnTConnectorClient.class);
 
-    private static PnTConnectorClient connectorClient = null;
+  private SessionFactory sessionFactory = SessionFactoryImpl.newInstance();
+  private Session session;
+  //  private String CMIS_BROWSER_BINDING_URL =
+  //
+  // "https://alfpnt.intranet.dev.int.devlab.redhat.com/alfresco/api/-default-/public/cmis/versions/1.1/browser";
+  File keyStore;
 
-    private PnTConnectorClient( String username, String password){
+  private static PnTConnectorClient connectorClient = null;
 
-        /*System.out.println("GETTING TRUST STORE");
+  private PnTConnectorClient(String username, String password, String folder) {
 
-        try {
-           keyStore = stream2file(getClass().getResourceAsStream("/pnt-portal.jks"));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+    /*System.out.println("GETTING TRUST STORE");
 
-        System.setProperty("javax.net.ssl.trustStore",keyStore.getPath());
-        System.setProperty("javax.net.ssl.trustStorePassword ","changeit");
-        */
-        Map<String, String> parameter = new HashMap<String, String>();
-        parameter.put(SessionParameter.USER,username);
-        parameter.put(SessionParameter.PASSWORD,password);
-        parameter.put(SessionParameter.BROWSER_URL,CMIS_BROWSER_BINDING_URL);
-        parameter.put(SessionParameter.BINDING_TYPE,BindingType.BROWSER.value());
-
-        List<Repository> repositories = this.sessionFactory.getRepositories(parameter);
-
-        if (!CollectionUtils.isEmpty(repositories)) {
-            Repository repository = repositories.get(0);
-            this.session = repository.createSession();
-
-        }
-
+    try {
+       keyStore = stream2file(getClass().getResourceAsStream("/pnt-portal.jks"));
+    } catch (IOException e) {
+        e.printStackTrace();
     }
 
-    public static PnTConnectorClient getConnectorClient( String username, String password){
-        if(connectorClient==null){
-            connectorClient = new PnTConnectorClient(username,password);
-        }
+    System.setProperty("javax.net.ssl.trustStore",keyStore.getPath());
+    System.setProperty("javax.net.ssl.trustStorePassword ","changeit");
+    */
+    Map<String, String> parameter = new HashMap<String, String>();
+    parameter.put(SessionParameter.USER, username);
+    parameter.put(SessionParameter.PASSWORD, password);
+    parameter.put(SessionParameter.ATOMPUB_URL, folder); // diff binding per type??
+    // TODO: binding Type in config?
+    // parameter.put(SessionParameter.BINDING_TYPE, BindingType.BROWSER.value());
+    parameter.put(SessionParameter.BINDING_TYPE, BindingType.ATOMPUB.value());
 
-        return connectorClient;
+    logger.info("Session using " + username + " -> " + folder);
+
+    List<Repository> repositories = this.sessionFactory.getRepositories(parameter);
+
+    if (!CollectionUtils.isEmpty(repositories)) {
+      Repository repository = repositories.get(0);
+      this.session = repository.createSession();
+    }
+  }
+
+  public static PnTConnectorClient getConnectorClient(
+      String username, String password, String startLink) {
+    if (connectorClient == null) {
+      connectorClient = new PnTConnectorClient(username, password, startLink);
     }
 
-    public Session getSession() {
-        return session;
-    }
+    return connectorClient;
+  }
 
-    public File stream2file(InputStream inputStream) throws IOException{
-        final File tempFile = File.createTempFile("stream2file",".tmp");
-        tempFile.deleteOnExit();
-        try(FileOutputStream out = new FileOutputStream(tempFile)){
-            IOUtils.copy(inputStream,out);
-        }
-        return tempFile;
-    }
+  public Session getSession() {
+    return session;
+  }
 
+  public File stream2file(InputStream inputStream) throws IOException {
+    final File tempFile = File.createTempFile("stream2file", ".tmp");
+    tempFile.deleteOnExit();
+    try (FileOutputStream out = new FileOutputStream(tempFile)) {
+      IOUtils.copy(inputStream, out);
+    }
+    return tempFile;
+  }
 }

--- a/random-connector/src/main/java/com/lucidworks/fusion/connector/plugin/PnTConnectorConfig.java
+++ b/random-connector/src/main/java/com/lucidworks/fusion/connector/plugin/PnTConnectorConfig.java
@@ -4,43 +4,38 @@ import com.lucidworks.fusion.connector.plugin.api.config.ConnectorConfig;
 import com.lucidworks.fusion.connector.plugin.api.config.ConnectorPluginProperties;
 import com.lucidworks.fusion.schema.SchemaAnnotations.Property;
 import com.lucidworks.fusion.schema.SchemaAnnotations.RootSchema;
+import com.lucidworks.fusion.schema.SchemaAnnotations.StringSchema;
 
 @RootSchema(
     name = "redhat.pnt.connector",
-    title = "PnT Connector",
+    title = "PnT Connector", // TODO What does Pnt mean?
     description = "A connector that retrieves documents from alfresco instance",
     category = "CMIS"
 )
 public interface PnTConnectorConfig extends ConnectorConfig<PnTConnectorConfig.Properties> {
 
-  @Property(
-      title = "Properties",
-      required = true
-  )
+  @Property(title = "Properties", required = true)
   Properties properties();
 
-  /**
-   * Connector specific settings
-   */
   interface Properties extends ConnectorPluginProperties {
 
-    @Property(
-            title = "Username",
-            description = "User who is accessing the alfresco instance"
-    )
+    @Property(title = "Username", description = "User who is accessing the alfresco instance")
     String username();
 
-    @Property(
-            title = "Password"
-    )
+    @Property(title = "Password")
+    @StringSchema(encrypted = true)
     String password();
 
     @Property(
-            title = "Start folder",
-            description = "Start location of the crawl (location must start with / and not end with /)"
+        title = "Alfesco Url",
+        description = "")
+    String url();
+
+    @Property(
+        title = "Start folder",
+        description = "Start location of the crawl (location must start with / and not end with /)"
     )
+    @StringSchema(defaultValue = "/")
     String startFolder();
-
   }
-
 }

--- a/random-connector/src/main/java/com/lucidworks/fusion/connector/plugin/PnTConnectorFetcher.java
+++ b/random-connector/src/main/java/com/lucidworks/fusion/connector/plugin/PnTConnectorFetcher.java
@@ -9,6 +9,7 @@ import com.lucidworks.fusion.connector.plugin.api.fetcher.type.content.MessageHe
 import org.apache.chemistry.opencmis.client.api.Document;
 import org.apache.chemistry.opencmis.client.api.Property;
 import org.apache.chemistry.opencmis.client.api.Session;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import javax.inject.Inject;
@@ -20,78 +21,76 @@ import java.util.stream.IntStream;
 
 public class PnTConnectorFetcher implements ContentFetcher {
 
-  private final Logger logger;
+  private static final Logger logger = LogManager.getLogger(PnTConnectorFetcher.class);
+
   private final PnTConnectorConfig pntConnectorConfig;
 
   private String username;
   private String password;
   private String startFolder;
+  private String url;
+
   private Session session;
   private PnTContentCrawler pnTContentCrawler;
   private List<String> documentIdList;
 
   @Inject
-  public PnTConnectorFetcher(
-      Logger logger,
-      PnTConnectorConfig pntConnectorConfig
-  ) {
-    this.logger = logger;
+  public PnTConnectorFetcher(PnTConnectorConfig pntConnectorConfig) {
     this.pntConnectorConfig = pntConnectorConfig;
   }
 
   @Override
   public StartResult start(StartContext startContext) {
-
     username = pntConnectorConfig.properties().username();
     password = pntConnectorConfig.properties().password();
+    url = pntConnectorConfig.properties().url();
     startFolder = pntConnectorConfig.properties().startFolder();
 
-    session = PnTConnectorClient.getConnectorClient(username,password).getSession();
+    session = PnTConnectorClient.getConnectorClient(username, password, url).getSession();
 
     pnTContentCrawler = new PnTContentCrawler(startFolder);
 
     documentIdList = pnTContentCrawler.getAllDocuments(session);
 
-    //List<Phase> phaseList = new ArrayList<>();
-    //phaseList.add(Phase.builder("test-phase1").build());
-    //phaseList.add(Phase.builder("test-phase2").build());
-
-    return new StartResult();//StartResult.builder().withPhases(phaseList).build();
+    return startContext.newResult();
   }
 
   @Override
   public PreFetchResult preFetch(PreFetchContext preFetchContext) {
 
-    IntStream.range(0, documentIdList.size()).asLongStream().forEach(i -> {
-      logger.info("Emitting candidate -> number {}", i);
-      Map<String, Object> data = Collections.singletonMap("number", (int)i);
-      preFetchContext.emitCandidate(MessageHelper.candidate(String.valueOf(i), Collections.emptyMap(), data).build());
-    });
+    IntStream.range(0, documentIdList.size())
+        .asLongStream()
+        .forEach(
+            i -> {
+              logger.info("Emitting candidate -> number {}", i);
+              Map<String, Object> data = Collections.singletonMap("number", (int) i);
+              preFetchContext.emitCandidate(
+                  MessageHelper.candidate(String.valueOf(i), Collections.emptyMap(), data).build());
+            });
     return preFetchContext.newResult();
   }
 
   @Override
   public FetchResult fetch(FetchContext fetchContext) {
 
-    Map<String,Object> contentMap = new HashMap<>();
+    Map<String, Object> contentMap = new HashMap<>();
 
     FetchInput input = fetchContext.getFetchInput();
     logger.info("Received FetchInput -> {}", input);
 
     long num = getNumber(input);
 
-    Document document = (Document)session.getObject(documentIdList.get((int)num));
+    Document document = (Document) session.getObject(documentIdList.get((int) num));
     logger.info("Emitting Document -> number {}", num);
 
-    for(Property p : document.getProperties()){
-      contentMap.put(p.getId()+"_s",p.getValueAsString());
+    for (Property p : document.getProperties()) {
+      contentMap.put(p.getId() + "_s", p.getValueAsString());
     }
 
     fetchContext.emitDocument(contentMap);
 
     return fetchContext.newResult();
   }
-
 
   private long getNumber(FetchInput input) {
     Object num = input.getMetadata().get("number");
@@ -103,5 +102,4 @@ public class PnTConnectorFetcher implements ContentFetcher {
       throw new RuntimeException(String.format("Invalid value for number: %s", num));
     }
   }
-
 }

--- a/random-connector/src/main/java/com/lucidworks/fusion/connector/plugin/PnTConnectorPlugin.java
+++ b/random-connector/src/main/java/com/lucidworks/fusion/connector/plugin/PnTConnectorPlugin.java
@@ -17,7 +17,7 @@ public class PnTConnectorPlugin extends ConnectorPluginModule {
   public ConnectorPlugin getConnectorPlugin() {
 
     return builder(PnTConnectorConfig.class)
-        .withFetcher(PnTConnectorFetcher.class)
+        .withFetcher("content", PnTConnectorFetcher.class)
         .build();
   }
 }


### PR DESCRIPTION
##  Fix connector integration with Fusion 4.1.0

* Tested using alfresco docker, see https://github.com/lucidworks/docker-alfresco 
* The following datasource configuration was used.
```
[ {
  "id" : "redhat-alfresco-datasource",
  "type" : "redhat.pnt.connector",
  "parserId" : "redhat-alfresco",
  "properties" : {
    "password" : "xXx-Redacted-xXx",
    "startFolder" : "/",
    "url" : "http://127.0.0.1:32777/alfresco/api/-default-/public/cmis/versions/1.1/atom",
    "username" : "admin",
    "collection" : "redhat-alfresco"
  },
  "diagnosticLogging" : true,
  "coreProperties" : { },
  "pipeline" : "redhat-alfresco",
  "connector" : "redhat.pnt.connector"
} ]
```

- please see Comments in the code.
